### PR TITLE
update the genome showing

### DIFF
--- a/R/blank_genome.R
+++ b/R/blank_genome.R
@@ -1,35 +1,39 @@
-blank_genome = function(ref = "GRCh38", chromosomes = paste0('chr', c(1:22, 'X', 'Y')), label_chr = -0.5, cex = 1)
-{
+blank_genome = function(ref = "GRCh38", chromosomes = paste0('chr', c(1:22, 'X', 'Y')), label_chr = -0.5, cex = 1){
   reference_coordinates = get_reference(ref) %>%
     filter(chr %in% chromosomes)
-
+  
   low = min(reference_coordinates$from)
   upp = max(reference_coordinates$to)
-
-  pl = ggplot(reference_coordinates) +
+  
+  
+  #change the solid and dashed lines for better separating chromosomes.
+  p1 = ggplot(reference_coordinates) +
     CNAqc:::my_ggplot_theme(cex = cex) +
-    geom_rect(
-      aes(
-        xmin = centromerStart,
-        xmax = centromerEnd,
-        ymin = 0,
-        ymax = Inf
-      ),
-      alpha = .3,
-      colour = 'gainsboro'
-    ) +
     geom_segment(
-      data = reference_coordinates,
       aes(
-        x = from,
-        xend = from,
+        x = centromerStart,
+        xend = centromerEnd,
         y = 0,
         yend = Inf
       ),
       size = .1,
       color = 'black',
       linetype = 8
-    ) +
+    ) 
+  
+  p1 = p1 + geom_rect(
+    data = reference_coordinates,
+    aes(
+      xmin = from,
+      xmax = from,
+      ymin = 0,
+      ymax = Inf
+    ),
+    alpha = 1,
+    colour = 'grey',
+  ) 
+  
+  p1 = p1 +
     geom_hline(yintercept = 0,
                size = 1,
                colour = 'gainsboro') +
@@ -44,28 +48,12 @@ blank_genome = function(ref = "GRCh38", chromosomes = paste0('chr', c(1:22, 'X',
     ggpubr::rotate_y_text() +
     # ggpubr::rotate_x_text() +
     # xlim(low, upp) +
+    
+    #set the chr names in the centromer positions.
     scale_x_continuous(
-      breaks = c(0, reference_coordinates$from, upp),
+      breaks = c(0, reference_coordinates$centromerStart, upp),
       labels = c("", gsub(pattern = 'chr', replacement = '', reference_coordinates$chr), "")
     )
-
-
-  # if(!is.null(label_chr) & !is.na(label_chr))
-  #   pl = pl +
-  #   geom_label(
-  #     data = reference_coordinates,
-  #     aes(
-  #       x = reference_coordinates$from,
-  #       y = label_chr,
-  #       label = gsub('chr', '', reference_coordinates$chr)
-  #     ),
-  #     hjust = 0,
-  #     colour = 'white',
-  #     fill = 'black',
-  #     size = 3
-  #   )
-
-
-  return(pl)
+  
+  return(p1)
 }
-

--- a/R/plot_multisample_CNA.R
+++ b/R/plot_multisample_CNA.R
@@ -61,7 +61,8 @@ plot_multisample_CNA = function(x)
 
   # Default blank genome -- remove labels with label_chr = NA
   bl_genome = suppressMessages(
-    CNAqc:::blank_genome(label_chr = NA) +
+    CNAqc:::blank_genome(ref = L[[1]]$reference_genome, chromosomes = chromosomes, 
+                         label_chr = NA) +
       labs(x = "", y = "")
   )
 


### PR DESCRIPTION

Hi: According to questions #12 and  #13, I create a PR.  

For the first question #13, I update the `blank_genomes()`.  The previous `blank_genomes()` used dashed lines to separate the chromosomes and solid lines to indicate the positions of the centromere. The update `blank_genomes()`  changed their orders, by using the solid lines to separate the chromosomes and dashed lines to indicate the position of the centromere. Next, the update `blank_genomes()` labels the chromosome's names in the centromere position rather than the beginning of the chromosomes.

For the second question #12, I update the code accordingly.

**The CNA views before the changes:**

```
x = CNAqc::init(
  example_dataset_CNAqc$snvs, 
  example_dataset_CNAqc$cna,
  example_dataset_CNAqc$purity,
  ref = 'hg19')

y = CNAqc::init(
  example_dataset_CNAqc$snvs, 
  example_dataset_CNAqc$cna %>%
    mutate(
      Major = ifelse(chr %in% c("chr3", "chr4", "chr1"), 1, Major),
      minor = ifelse(chr %in% c("chr3", "chr4", "chr1"), 1, minor)
    ),
  example_dataset_CNAqc$purity,
  ref = 'hg19')

plot_multisample_CNA(list(`Original` = x, `Copy` = x, `Faked_diploid` = y, `PCAWG` = CNAqc::example_PCAWG))

```
<img width="506" alt="image" src="https://user-images.githubusercontent.com/19546092/162601721-4ddb1a58-03e3-414b-b7fc-eee6fc899f72.png">


**The CNA views after the changes:**

![image](https://user-images.githubusercontent.com/19546092/162601799-537c34ba-f125-47ec-bb96-9e634fdea9ee.png)




